### PR TITLE
[Refactoring] View에서 비지니스 로직 분리

### DIFF
--- a/Whistle_WatchOS WatchKit Extension/CountdownTimerView.swift
+++ b/Whistle_WatchOS WatchKit Extension/CountdownTimerView.swift
@@ -11,9 +11,7 @@ import Combine
 struct TimerView: View {
     @State private var minute = 0
     @State private var second = 0
-    @State private var isRunning = false
     @State private var showPicker = true
-    @State private var timerCancellable: AnyCancellable?
     
     @StateObject private var timerManager = TimerManager()
     
@@ -55,32 +53,23 @@ struct TimerView: View {
                 
                 Spacer().frame(height: 20)
                 
-                HStack {
-                    Button(action: {
+                ControlButtons(
+                    isRunning: timerManager.isRunning,
+                    showPicker: showPicker,
+                    onReset: {
                         timerManager.resetTimer()
-                    }) {
-                        Text("Reset")
-                    }
-                    .controlSize(.mini)
-                    .buttonStyle(.borderedProminent)
-                    .tint(!timerManager.isRunning && !showPicker ? .orange : nil)
-                    .disabled(showPicker)
-                    
-                    Spacer().frame(width: 20)
-                    
-                    Button(action: {
+                        showPicker = true
+                    },
+                    onStartStop: {
                         if !timerManager.isRunning {
+                            timerManager.setTimer(minute: minute, second: second)
                             timerManager.startTimer()
+                            showPicker = false
                         } else {
                             timerManager.stopTimer()
                         }
-                    }) {
-                        Text(timerManager.isRunning ? "Stop" : "Start")
                     }
-                    .controlSize(.mini)
-                    .buttonStyle(.borderedProminent)
-                    .tint(timerManager.isRunning ? .green : .red)
-                }
+                )
             }
             .padding(.top, -25)
         }
@@ -98,6 +87,35 @@ struct TimerDisplay: View {
         }
     }
 }
+
+struct ControlButtons: View {
+    let isRunning: Bool
+    let showPicker: Bool
+    let onReset: () -> Void
+    let onStartStop: () -> Void
+    
+    var body: some View {
+        HStack {
+            Button(action: onReset) {
+                Text("Reset")
+            }
+            .controlSize(.mini)
+            .buttonStyle(.borderedProminent)
+            .tint(!isRunning && !showPicker ? .orange : nil)
+            .disabled(showPicker)
+            
+            Spacer().frame(width: 20)
+            
+            Button(action: onStartStop) {
+                Text(isRunning ? "Stop" : "Start")
+            }
+            .controlSize(.mini)
+            .buttonStyle(.borderedProminent)
+            .tint(isRunning ? .green : .red)
+        }
+    }
+}
+
 class TimerManager: ObservableObject {
     @Published private(set) var remainingSeconds = 0
     @Published private(set) var isRunning = false

--- a/Whistle_WatchOS WatchKit Extension/CountdownTimerView.swift
+++ b/Whistle_WatchOS WatchKit Extension/CountdownTimerView.swift
@@ -12,7 +12,6 @@ struct TimerView: View {
     @State private var minute = 0
     @State private var second = 0
     @State private var isRunning = false
-    @State private var remainingSeconds = 0
     @State private var showPicker = true
     @State private var timerCancellable: AnyCancellable?
     
@@ -49,10 +48,7 @@ struct TimerView: View {
                             .frame(maxWidth: geometry.size.width / 2)
                         }
                     } else {
-                        HStack {
-                            Text(String(format: "%02d : %02d", timerManager.remainingSeconds / 60, timerManager.remainingSeconds % 60))
-                                .font(.system(size: 60, weight: .semibold))
-                        }
+                        TimerDisplay(remainingSeconds: timerManager.remainingSeconds)
                     }
                 }
                 .frame(height: geometry.size.height * 0.7)
@@ -92,6 +88,16 @@ struct TimerView: View {
     }
 }
 
+struct TimerDisplay: View {
+    let remainingSeconds: Int
+    
+    var body: some View {
+        HStack {
+            Text(String(format: "%02d : %02d", remainingSeconds / 60, remainingSeconds % 60))
+                .font(.system(size: 60, weight: .semibold))
+        }
+    }
+}
 class TimerManager: ObservableObject {
     @Published private(set) var remainingSeconds = 0
     @Published private(set) var isRunning = false

--- a/Whistle_WatchOS WatchKit Extension/CountdownTimerView.swift
+++ b/Whistle_WatchOS WatchKit Extension/CountdownTimerView.swift
@@ -98,6 +98,10 @@ class TimerManager: ObservableObject {
     
     private var timerCancellable: AnyCancellable?
     
+    func setTimer(minute: Int, second: Int) {
+        remainingSeconds = minute * 60 + second
+    }
+    
     func startTimer() {
         guard remainingSeconds > 0 else { return }
         


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 기능 구현 방식 변경
- [ ] 버그 수정
- [ ] 그 외

## 변경 내용
`View`에서 비지니스 로직을 따로 분리

- 타이머 관련 비즈니스 로직(`start`, `stop`, `reset`)을 관리하도록 분리
  - `ViewModel`개념의 `TimerManager`를 만들어 데이터 바인딩 부분은 넣지 않고 비지니스 로직만 들어가게 하고자 했으나
  - `TimerManager`가 데이터 바인딩에 사용되는 `@Published` 속성(`remainingSeconds`, `isRunning`)을 가지게 됐다.
  대신 두 속성은 상태 업데이트를 외부에 알리기 위한 목적이므로 비즈니스 로직에 포함된다고 생각한다.
  -> 그래서 `View`에서 비지니스 로직을 따로 분리하여 넣되, 데이터 바인딩을 위한 부분은 최소한으로 넣도록 개선했다.
- `TimerDisplay`와 `ControlButtons`라는 별도 View 컴포넌트를 만들어 UI를 분리해서 가독성과 재사용성을 높였다.
(`TimerView`는 전체적인 레이아웃을 관리하고, 개별 컴포넌트는 각자의 역할을 하도록)

## 반영 브랜치
- #17 