### PR TITLE
[Refactoring] Whistle - View에서 비지니스 로직 분리 및 Combine 프레임워크 적용

### DIFF
--- a/Whistle_WatchOS WatchKit Extension/WhistleView.swift
+++ b/Whistle_WatchOS WatchKit Extension/WhistleView.swift
@@ -15,18 +15,11 @@ struct WhistleView: View {
     var body: some View {
         ScrollView(.vertical) {
             VStack {
-                Button(action: {
+                WhistleButton(action: {
                     whistleManager.playSound()
-                }) {
-                    Image("whistleImg")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .buttonStyle(BorderedButtonStyle())
-                }
-                .buttonStyle(.plain)
+                })
                 
-                Slider(value: $whistleManager.volume, in: 0...10, step: 1)
-                    .tint(.green)
+                WhistleSlider(volume: $whistleManager.volume)
             }
             .padding(5)
         }
@@ -37,6 +30,29 @@ struct WhistleView: View {
         .onDisappear {
             whistleManager.cancelSubscriptions()
         }
+    }
+}
+
+struct WhistleButton: View {
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Image("whistleImg")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .buttonStyle(BorderedButtonStyle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct WhistleSlider: View {
+    @Binding var volume: Float
+    
+    var body: some View {
+        Slider(value: $volume, in: 0...10, step: 1)
+            .tint(.green)
     }
 }
 


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 기능 구현 방식 변경
- [ ] 버그 수정
- [ ] 그 외

## 변경 내용
- `WhistleView`에서 비즈니스 로직 분리
  - `WhistleManager` 클래스를 만들어 뷰와 비즈니스 로직을 분리
- `volume`프로퍼티의 상태를 구독하고 변경이 있을 때 `AVAudioPlayer`의 볼륨이 자동으로 업데이트 되도록 반응형으로 개선
  - `volume` 값 변경을 Combine의 `sink`를 사용하여 반응형으로 처리
  - `AnyCancellable`로 구독을 관리하고 `onDisappear`에서 구독을 해제하여 메모리 누수 방지
- `Whistle Button`, `Volume Slider` 하위 뷰를 분리하여 재사용성 높임

## 반영 브랜치
- #19 